### PR TITLE
HOTFIX: Bump pytest, py, and psycopg2-binary versions

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -17,11 +17,11 @@ Mako==1.1.4
 MarkupSafe==1.1.1
 packaging==20.9
 pluggy==0.13.1
-psycopg2-binary==2.8.6
-py==1.10.0
+psycopg2-binary==2.9.5
+py==1.11.0
 pycodestyle==2.6.0
 pyparsing==2.4.7
-pytest==6.2.4
+pytest==7.1.1
 python-dateutil==2.8.1
 python-dotenv==0.15.0
 python-editor==1.0.4


### PR DESCRIPTION
Applied to C18 (using versions checked for compatibility on previous projects), but this should get up to gold.